### PR TITLE
Compile `server.ts` for a smaller docker image

### DIFF
--- a/Dockerfile.compiled
+++ b/Dockerfile.compiled
@@ -3,7 +3,6 @@
 
 FROM gcr.io/distroless/cc AS cc
 FROM ghcr.io/kikkia/yt-cipher:master AS yt-cipher
-#FROM tcely/deno AS deno
 FROM denoland/deno:alpine AS deno
 
 COPY --from=yt-cipher /usr/src/app /usr/src/app


### PR DESCRIPTION
Instead of 357 MB, this can run the server using 102 MB.

```
REPOSITORY                              TAG         IMAGE ID       CREATED          SIZE
tcely/yt-cipher                         latest      8aa05b925d06   46 minutes ago   102MB
ghcr.io/kikkia/yt-cipher                master      a0f8a3405023   3 weeks ago      357MB
```