### PR TITLE
Use `XDG_CACHE_HOME` environment variable

### DIFF
--- a/src/playerCache.ts
+++ b/src/playerCache.ts
@@ -3,7 +3,8 @@ import { ensureDir } from "https://deno.land/std@0.224.0/fs/ensure_dir.ts";
 import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
 import { cacheSize, playerScriptFetches } from "./metrics.ts";
 
-export const CACHE_DIR = join(Deno.cwd(), 'player_cache');
+export const CACHE_HOME = Deno.env.get("XDG_CACHE_HOME") || join(Deno.env.get("HOME"), '.cache');
+export const CACHE_DIR = join(CACHE_HOME, 'yt-cipher', 'player_cache');
 
 export async function getPlayerFilePath(playerUrl: string): Promise<string> {
     // This hash of the player script url will mean that diff region scripts are treated as unequals, even for the same version #


### PR DESCRIPTION
The previous behavior of using the current directory was unexpected, especially without a way to provide a configuration.

The `XDG_CACHE_HOME` variable and the default value for when it is not set, or empty, is described at: https://specifications.freedesktop.org/basedir/latest/#variables